### PR TITLE
Optional Fastify /metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The following ENV Variables can be used to control qryn parameters and backend s
 | FASTIFY_BODYLIMIT      | 5242880   | API Maximum payload size in bytes |
 | FASTIFY_REQUESTTIMEOUT | 0 | API Maximum Request Timeout in ms |
 | FASTIFY_MAXREQUESTS    | 0 | API Maximum Requests per socket |
+| FASTIFY_METRICS.       | false | API /metrics exporter |
 | TEMPO_SPAN             | 24 | Default span for Tempo queries in hours |
 | TEMPO_TAGTRACE         | false | Optional tagging of TraceID (expensive) |
 | DEBUG  			             | false  	    | Debug Mode (for backwards compatibility) 		|

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The following ENV Variables can be used to control qryn parameters and backend s
 | FASTIFY_BODYLIMIT      | 5242880   | API Maximum payload size in bytes |
 | FASTIFY_REQUESTTIMEOUT | 0 | API Maximum Request Timeout in ms |
 | FASTIFY_MAXREQUESTS    | 0 | API Maximum Requests per socket |
-| FASTIFY_METRICS.       | false | API /metrics exporter |
+| FASTIFY_METRICS        | false | API /metrics exporter |
 | TEMPO_SPAN             | 24 | Default span for Tempo queries in hours |
 | TEMPO_TAGTRACE         | false | Optional tagging of TraceID (expensive) |
 | DEBUG  			             | false  	    | Debug Mode (for backwards compatibility) 		|

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "fastify": "^3.25.1",
     "fastify-basic-auth": "^0.4.0",
     "fastify-cors": "^6.0.2",
+    "fastify-metrics": "^8.0.0",
     "fastify-static": "^4.5.0",
     "fastify-url-data": "^2.4.0",
     "fastify-websocket": "^4.0.0",

--- a/qryn.js
+++ b/qryn.js
@@ -182,6 +182,11 @@ const fastify = require('fastify')({
 fastify.register(require('fastify-url-data'))
 fastify.register(require('fastify-websocket'))
 
+/* Fastify local metrics exporter */
+if (process.env.FASTIFY_METRICS){
+  const metricsPlugin = require('fastify-metrics');
+  fastify.register(metricsPlugin, { endpoint: '/metrics' });
+}
 /* CORS Helper */
 const CORS = process.env.CORS_ALLOW_ORIGIN || '*'
 fastify.register(require('fastify-cors'), {


### PR DESCRIPTION
Partial, super simple but quite comprehensive proposal for #11 

* To enabled set the `FASTIFY_METRICS` ENV variable to any value before execution

_Bonus points: data can be scraped into qryn itself using the value insert extension_

Sample output:
```
# HELP process_cpu_user_seconds_total Total user CPU time spent in seconds.
# TYPE process_cpu_user_seconds_total counter
process_cpu_user_seconds_total 29.188000000000002

# HELP process_cpu_system_seconds_total Total system CPU time spent in seconds.
# TYPE process_cpu_system_seconds_total counter
process_cpu_system_seconds_total 4.828

# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
# TYPE process_cpu_seconds_total counter
process_cpu_seconds_total 34.016

# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1656447249

# HELP process_resident_memory_bytes Resident memory size in bytes.
# TYPE process_resident_memory_bytes gauge
process_resident_memory_bytes 132153344

# HELP process_virtual_memory_bytes Virtual memory size in bytes.
# TYPE process_virtual_memory_bytes gauge
process_virtual_memory_bytes 22686072832

# HELP process_heap_bytes Process heap size in bytes.
# TYPE process_heap_bytes gauge
process_heap_bytes 187228160

# HELP process_open_fds Number of open file descriptors.
# TYPE process_open_fds gauge
process_open_fds 26

# HELP process_max_fds Maximum number of open file descriptors.
# TYPE process_max_fds gauge
process_max_fds 1048576

# HELP nodejs_eventloop_lag_seconds Lag of event loop in seconds.
# TYPE nodejs_eventloop_lag_seconds gauge
nodejs_eventloop_lag_seconds 0.013482144

# HELP nodejs_eventloop_lag_min_seconds The minimum recorded event loop delay.
# TYPE nodejs_eventloop_lag_min_seconds gauge
nodejs_eventloop_lag_min_seconds 0.007090176

# HELP nodejs_eventloop_lag_max_seconds The maximum recorded event loop delay.
# TYPE nodejs_eventloop_lag_max_seconds gauge
nodejs_eventloop_lag_max_seconds 0.032522239

# HELP nodejs_eventloop_lag_mean_seconds The mean of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_mean_seconds gauge
nodejs_eventloop_lag_mean_seconds 0.010205625217047348

# HELP nodejs_eventloop_lag_stddev_seconds The standard deviation of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_stddev_seconds gauge
nodejs_eventloop_lag_stddev_seconds 0.000688404497605469

# HELP nodejs_eventloop_lag_p50_seconds The 50th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p50_seconds gauge
nodejs_eventloop_lag_p50_seconds 0.010141695

# HELP nodejs_eventloop_lag_p90_seconds The 90th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p90_seconds gauge
nodejs_eventloop_lag_p90_seconds 0.010158079

# HELP nodejs_eventloop_lag_p99_seconds The 99th percentile of the recorded event loop delays.
# TYPE nodejs_eventloop_lag_p99_seconds gauge
nodejs_eventloop_lag_p99_seconds 0.013393919

# HELP nodejs_active_handles Number of active libuv handles grouped by handle type. Every handle type is C++ class name.
# TYPE nodejs_active_handles gauge
nodejs_active_handles{type="Pipe"} 1
nodejs_active_handles{type="Socket"} 4
nodejs_active_handles{type="MessagePort"} 1
nodejs_active_handles{type="Server"} 1

# HELP nodejs_active_handles_total Total number of active handles.
# TYPE nodejs_active_handles_total gauge
nodejs_active_handles_total 7

# HELP nodejs_active_requests Number of active libuv requests grouped by request type. Every request type is C++ class name.
# TYPE nodejs_active_requests gauge

# HELP nodejs_active_requests_total Total number of active requests.
# TYPE nodejs_active_requests_total gauge
nodejs_active_requests_total 0

# HELP nodejs_heap_size_total_bytes Process heap size from Node.js in bytes.
# TYPE nodejs_heap_size_total_bytes gauge
nodejs_heap_size_total_bytes 66576384

# HELP nodejs_heap_size_used_bytes Process heap size used from Node.js in bytes.
# TYPE nodejs_heap_size_used_bytes gauge
nodejs_heap_size_used_bytes 40804640

# HELP nodejs_external_memory_bytes Node.js external memory size in bytes.
# TYPE nodejs_external_memory_bytes gauge
nodejs_external_memory_bytes 1994074

# HELP nodejs_heap_space_size_total_bytes Process heap space size total from Node.js in bytes.
# TYPE nodejs_heap_space_size_total_bytes gauge
nodejs_heap_space_size_total_bytes{space="read_only"} 151552
nodejs_heap_space_size_total_bytes{space="new"} 33554432
nodejs_heap_space_size_total_bytes{space="old"} 26898432
nodejs_heap_space_size_total_bytes{space="code"} 1671168
nodejs_heap_space_size_total_bytes{space="map"} 1314816
nodejs_heap_space_size_total_bytes{space="large_object"} 2650112
nodejs_heap_space_size_total_bytes{space="code_large_object"} 335872
nodejs_heap_space_size_total_bytes{space="new_large_object"} 0

# HELP nodejs_heap_space_size_used_bytes Process heap space size used from Node.js in bytes.
# TYPE nodejs_heap_space_size_used_bytes gauge
nodejs_heap_space_size_used_bytes{space="read_only"} 150392
nodejs_heap_space_size_used_bytes{space="new"} 9983432
nodejs_heap_space_size_used_bytes{space="old"} 25760584
nodejs_heap_space_size_used_bytes{space="code"} 1142496
nodejs_heap_space_size_used_bytes{space="map"} 876528
nodejs_heap_space_size_used_bytes{space="large_object"} 2629896
nodejs_heap_space_size_used_bytes{space="code_large_object"} 274016
nodejs_heap_space_size_used_bytes{space="new_large_object"} 0

# HELP nodejs_heap_space_size_available_bytes Process heap space size available from Node.js in bytes.
# TYPE nodejs_heap_space_size_available_bytes gauge
nodejs_heap_space_size_available_bytes{space="read_only"} 0
nodejs_heap_space_size_available_bytes{space="new"} 6775352
nodejs_heap_space_size_available_bytes{space="old"} 885416
nodejs_heap_space_size_available_bytes{space="code"} 199136
nodejs_heap_space_size_available_bytes{space="map"} 436096
nodejs_heap_space_size_available_bytes{space="large_object"} 0
nodejs_heap_space_size_available_bytes{space="code_large_object"} 0
nodejs_heap_space_size_available_bytes{space="new_large_object"} 16758784

# HELP nodejs_version_info Node.js version info.
# TYPE nodejs_version_info gauge
nodejs_version_info{version="v14.19.3",major="14",minor="19",patch="3"} 1

# HELP nodejs_gc_duration_seconds Garbage collection duration by kind, one of major, minor, incremental or weakcb.
# TYPE nodejs_gc_duration_seconds histogram
nodejs_gc_duration_seconds_bucket{le="0.001",kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="0.01",kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="0.1",kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="1",kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="2",kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="5",kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="weakcb"} 1
nodejs_gc_duration_seconds_sum{kind="weakcb"} 4.22e-7
nodejs_gc_duration_seconds_count{kind="weakcb"} 1
nodejs_gc_duration_seconds_bucket{le="0.001",kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="0.01",kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="0.1",kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="1",kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="2",kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="5",kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="incremental"} 10
nodejs_gc_duration_seconds_sum{kind="incremental"} 0.0017331870000000002
nodejs_gc_duration_seconds_count{kind="incremental"} 10
nodejs_gc_duration_seconds_bucket{le="0.001",kind="major"} 0
nodejs_gc_duration_seconds_bucket{le="0.01",kind="major"} 5
nodejs_gc_duration_seconds_bucket{le="0.1",kind="major"} 5
nodejs_gc_duration_seconds_bucket{le="1",kind="major"} 5
nodejs_gc_duration_seconds_bucket{le="2",kind="major"} 5
nodejs_gc_duration_seconds_bucket{le="5",kind="major"} 5
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="major"} 5
nodejs_gc_duration_seconds_sum{kind="major"} 0.018824678999999997
nodejs_gc_duration_seconds_count{kind="major"} 5
nodejs_gc_duration_seconds_bucket{le="0.001",kind="minor"} 155
nodejs_gc_duration_seconds_bucket{le="0.01",kind="minor"} 160
nodejs_gc_duration_seconds_bucket{le="0.1",kind="minor"} 160
nodejs_gc_duration_seconds_bucket{le="1",kind="minor"} 160
nodejs_gc_duration_seconds_bucket{le="2",kind="minor"} 160
nodejs_gc_duration_seconds_bucket{le="5",kind="minor"} 160
nodejs_gc_duration_seconds_bucket{le="+Inf",kind="minor"} 160
nodejs_gc_duration_seconds_sum{kind="minor"} 0.11541616099999992
nodejs_gc_duration_seconds_count{kind="minor"} 160

# HELP http_request_duration_seconds request duration in seconds
# TYPE http_request_duration_seconds histogram
http_request_duration_seconds_bucket{le="0.05",method="POST",route="/loki/api/v1/push",status_code="204"} 9605
http_request_duration_seconds_bucket{le="0.1",method="POST",route="/loki/api/v1/push",status_code="204"} 24362
http_request_duration_seconds_bucket{le="0.5",method="POST",route="/loki/api/v1/push",status_code="204"} 27846
http_request_duration_seconds_bucket{le="1",method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_duration_seconds_bucket{le="3",method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_duration_seconds_bucket{le="5",method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_duration_seconds_bucket{le="10",method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_duration_seconds_bucket{le="+Inf",method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_duration_seconds_sum{method="POST",route="/loki/api/v1/push",status_code="204"} 1900.8899339839934
http_request_duration_seconds_count{method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_duration_seconds_bucket{le="0.05",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="0.1",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="0.5",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="1",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="3",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="5",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="10",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_sum{method="GET",route="/metrics",status_code="200"} 0.014720676
http_request_duration_seconds_count{method="GET",route="/metrics",status_code="200"} 1
http_request_duration_seconds_bucket{le="0.05",method="GET",route="/*",status_code="200"} 0
http_request_duration_seconds_bucket{le="0.1",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="0.5",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="1",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="3",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="5",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="10",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_sum{method="GET",route="/*",status_code="200"} 0.082517122
http_request_duration_seconds_count{method="GET",route="/*",status_code="200"} 1
http_request_duration_seconds_bucket{le="0.05",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="0.1",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="0.5",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="1",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="3",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="5",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="10",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
http_request_duration_seconds_sum{method="GET",route="/loki/api/v1/query_range",status_code="200"} 0.03420995
http_request_duration_seconds_count{method="GET",route="/loki/api/v1/query_range",status_code="200"} 2

# HELP http_request_summary_seconds request duration in seconds summary
# TYPE http_request_summary_seconds summary
http_request_summary_seconds{quantile="0.5",method="POST",route="/loki/api/v1/push",status_code="204"} 0.06533624649285263
http_request_summary_seconds{quantile="0.9",method="POST",route="/loki/api/v1/push",status_code="204"} 0.10237315848954938
http_request_summary_seconds{quantile="0.95",method="POST",route="/loki/api/v1/push",status_code="204"} 0.10770702393358417
http_request_summary_seconds{quantile="0.99",method="POST",route="/loki/api/v1/push",status_code="204"} 0.26062471240500673
http_request_summary_seconds_sum{method="POST",route="/loki/api/v1/push",status_code="204"} 1900.3144687129961
http_request_summary_seconds_count{method="POST",route="/loki/api/v1/push",status_code="204"} 27922
http_request_summary_seconds{quantile="0.5",method="GET",route="/metrics",status_code="200"} 0.01465844
http_request_summary_seconds{quantile="0.9",method="GET",route="/metrics",status_code="200"} 0.01465844
http_request_summary_seconds{quantile="0.95",method="GET",route="/metrics",status_code="200"} 0.01465844
http_request_summary_seconds{quantile="0.99",method="GET",route="/metrics",status_code="200"} 0.01465844
http_request_summary_seconds_sum{method="GET",route="/metrics",status_code="200"} 0.01465844
http_request_summary_seconds_count{method="GET",route="/metrics",status_code="200"} 1
http_request_summary_seconds{quantile="0.5",method="GET",route="/*",status_code="200"} 0.082431831
http_request_summary_seconds{quantile="0.9",method="GET",route="/*",status_code="200"} 0.082431831
http_request_summary_seconds{quantile="0.95",method="GET",route="/*",status_code="200"} 0.082431831
http_request_summary_seconds{quantile="0.99",method="GET",route="/*",status_code="200"} 0.082431831
http_request_summary_seconds_sum{method="GET",route="/*",status_code="200"} 0.082431831
http_request_summary_seconds_count{method="GET",route="/*",status_code="200"} 1
http_request_summary_seconds{quantile="0.5",method="GET",route="/loki/api/v1/query_range",status_code="200"} 0.017050224
http_request_summary_seconds{quantile="0.9",method="GET",route="/loki/api/v1/query_range",status_code="200"} 0.020865905
http_request_summary_seconds{quantile="0.95",method="GET",route="/loki/api/v1/query_range",status_code="200"} 0.020865905
http_request_summary_seconds{quantile="0.99",method="GET",route="/loki/api/v1/query_range",status_code="200"} 0.020865905
http_request_summary_seconds_sum{method="GET",route="/loki/api/v1/query_range",status_code="200"} 0.034100448
http_request_summary_seconds_count{method="GET",route="/loki/api/v1/query_range",status_code="200"} 2
```