### PR TITLE
Promql to LogQL emulation

### DIFF
--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -1,0 +1,10 @@
+/* Emulated PromQL Query Handler */
+
+async function handler (req, res) {
+  req.log.debug('GET /api/v1/*')
+  const resp = {"status": "success", "data": {}};
+  res.send(resp)
+  return
+}
+
+module.exports = handler

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -1,0 +1,34 @@
+/* Emulated PromQL Query Handler */
+
+const { p2l } = require('@qxip/promql2logql');
+
+async function handler (req, res) {
+  req.log.debug('GET /loki/api/v1/query')
+  const resp = { streams: [] }
+  if (!req.query.query) {
+    res.send(resp)
+    return
+  }
+  /* remove newlines */
+  req.query.query = req.query.query.replace(/\n/g, ' ')
+  /* transpile to logql */
+  try {
+    req.query.query = p2l(req.query.query);
+  } catch(e) {
+    req.log.error({ err })
+    res.send(resp)
+  }
+  /* scan fingerprints */
+  /* TODO: handle time tag + direction + limit to govern the query output */
+  try {
+    await this.instantQueryScan(
+      req.query,
+      { res: res.raw }
+    )
+  } catch (err) {
+    req.log.error({ err })
+    res.send(resp)
+  }
+}
+
+module.exports = handler

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -1,6 +1,7 @@
 /* Emulated PromQL Query Handler */
 
 const { p2l } = require('@qxip/promql2logql');
+const empty = '{"status" : "success", "data" : {"resultType" : "scalar", "result" : []}}'; // to be removed
 
 async function handler (req, res) {
   req.log.debug('GET /loki/api/v1/query')
@@ -16,7 +17,7 @@ async function handler (req, res) {
     req.query.query = p2l(req.query.query);
   } catch(e) {
     req.log.error({ err })
-    res.send(resp)
+    res.send(empty)
   }
   /* scan fingerprints */
   /* TODO: handle time tag + direction + limit to govern the query output */
@@ -27,7 +28,7 @@ async function handler (req, res) {
     )
   } catch (err) {
     req.log.error({ err })
-    res.send(resp)
+    res.send(empty)
   }
 }
 

--- a/lib/handlers/prom_query_range.js
+++ b/lib/handlers/prom_query_range.js
@@ -9,11 +9,10 @@
   regexp: a regex to filter the returned results, will eventually be rolled into the query language
 */
 
-const { p2l } = require('@qxip/promql2logql');
+const { p2l } = require('@qxip/promql2logql')
 
 async function handler (req, res) {
   req.log.debug('GET /api/v1/query_range')
-  const params = req.query
   const resp = { streams: [] }
   if (!req.query.query) {
     res.send(resp)
@@ -27,7 +26,7 @@ async function handler (req, res) {
   }
   // Convert PromQL to LogQL and execute
   try {
-    req.query.query = p2l(req.query.query);
+    req.query.query = p2l(req.query.query)
     await this.scanFingerprints(
       {
         ...req.query,

--- a/lib/handlers/prom_query_range.js
+++ b/lib/handlers/prom_query_range.js
@@ -29,7 +29,11 @@ async function handler (req, res) {
   try {
     req.query.query = p2l(req.query.query);
     await this.scanFingerprints(
-      req.query,
+      {
+        ...req.query,
+        start: parseInt(req.query.start) * 1e9,
+        end: parseInt(req.query.end) * 1e9
+      },
       { res: res.raw }
     )
     res.sent = true

--- a/lib/handlers/prom_query_range.js
+++ b/lib/handlers/prom_query_range.js
@@ -1,0 +1,42 @@
+/* Emulated PromQL Query Handler */
+/*
+  Converts PromQL to LogQL queries, accepts the following parameters in the query-string:
+  query: a PromQL query
+  limit: max number of entries to return
+  start: the start time for the query, as a nanosecond Unix epoch (nanoseconds since 1970)
+  end: the end time for the query, as a nanosecond Unix epoch (nanoseconds since 1970)
+  direction: forward or backward, useful when specifying a limit
+  regexp: a regex to filter the returned results, will eventually be rolled into the query language
+*/
+
+const { p2l } = require('@qxip/promql2logql');
+
+async function handler (req, res) {
+  req.log.debug('GET /api/v1/query_range')
+  const params = req.query
+  const resp = { streams: [] }
+  if (!req.query.query) {
+    res.send(resp)
+    return
+  }
+  /* remove newlines */
+  req.query.query = req.query.query.replace(/\n/g, ' ')
+  if (!req.query.query) {
+    res.code(400).send('invalid query')
+    return
+  }
+  // Convert PromQL to LogQL and execute
+  try {
+    req.query.query = p2l(req.query.query);
+    await this.scanFingerprints(
+      req.query,
+      { res: res.raw }
+    )
+    res.sent = true
+  } catch (err) {
+    req.log.error({ err })
+    res.send(resp)
+  }
+}
+
+module.exports = handler

--- a/lib/handlers/promlabel.js
+++ b/lib/handlers/promlabel.js
@@ -1,0 +1,30 @@
+/* Label Handler */
+/*
+   For retrieving the names of the labels one can query on.
+   Responses looks like this:
+{
+  "values": [
+    "instance",
+    "job",
+    ...
+  ]
+}
+*/
+
+const clickhouse = require('../db/clickhouse')
+const utils = require('../utils')
+
+async function handler (req, res) {
+  req.log.debug('GET /loki/api/v1/label')
+  let where = [
+    null, // req.query.start && !isNaN(parseInt(req.query.start)) ? `date >= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.start)}, 1000000000)))` : null,
+    null, //req.query.end && !isNaN(parseInt(req.query.end)) ? `date <= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.end)}, 1000000000)))` : null
+  ].filter(w => w)
+  where = where.length ? `WHERE ${where.join(' AND ')}` : ''
+  const q = `SELECT DISTINCT key FROM time_series_gin ${where} FORMAT JSON`
+  const allLabels = await clickhouse.rawRequest(q, null, utils.DATABASE_NAME())
+  const resp = { status: 'success', data: allLabels.data.data.map(r => r.key) }
+  res.send(resp)
+}
+
+module.exports = handler

--- a/lib/handlers/promlabel.js
+++ b/lib/handlers/promlabel.js
@@ -11,20 +11,15 @@
 }
 */
 
-const clickhouse = require('../db/clickhouse')
-const utils = require('../utils')
-
 async function handler (req, res) {
-  req.log.debug('GET /loki/api/v1/label')
-  let where = [
-    null, // req.query.start && !isNaN(parseInt(req.query.start)) ? `date >= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.start)}, 1000000000)))` : null,
-    null, //req.query.end && !isNaN(parseInt(req.query.end)) ? `date <= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.end)}, 1000000000)))` : null
-  ].filter(w => w)
-  where = where.length ? `WHERE ${where.join(' AND ')}` : ''
-  const q = `SELECT DISTINCT key FROM time_series_gin ${where} FORMAT JSON`
-  const allLabels = await clickhouse.rawRequest(q, null, utils.DATABASE_NAME())
-  const resp = { status: 'success', data: allLabels.data.data.map(r => r.key) }
-  res.send(resp)
+  await require('./label.js')({
+    ...req,
+    query: {
+      ...req.query,
+      start: req.query.start ? parseInt(req.query.start) * 1e9 : undefined,
+      end: req.query.end ? parseInt(req.query.end) * 1e9 : undefined
+    }
+  }, res)
 }
 
 module.exports = handler

--- a/lib/handlers/promlabel_values.js
+++ b/lib/handlers/promlabel_values.js
@@ -11,22 +11,15 @@
 }
 */
 
-const clickhouse = require('../db/clickhouse')
-const Sql = require('@cloki/clickhouse-sql')
-const utils = require('../utils')
-
 async function handler (req, res) {
-  req.log.debug(`GET /api/prom/label/${req.params.name}/values`)
-  let where = [
-    `key = ${Sql.val(req.params.name)}`,
-    null, //req.query.start && !isNaN(parseInt(req.query.start)) ? `date >= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.start)}, 1000000000)))` : null,
-    null, // req.query.end && !isNaN(parseInt(req.query.end)) ? `date <= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.end)}, 1000000000)))` : null
-  ].filter(w => w)
-  where = `WHERE ${where.join(' AND ')}`
-  const q = `SELECT DISTINCT val FROM time_series_gin ${where} FORMAT JSON`
-  const allValues = await clickhouse.rawRequest(q, null, utils.DATABASE_NAME())
-  const resp = { status: 'success', data: allValues.data.data.map(r => r.val) }
-  res.send(resp)
+  await require('./label_values.js')({
+    ...req,
+    query: {
+      ...req.query,
+      start: req.query.start ? parseInt(req.query.start) * 1e9 : undefined,
+      end: req.query.end ? parseInt(req.query.end) * 1e9 : undefined
+    }
+  }, res)
 }
 
 module.exports = handler

--- a/lib/handlers/promlabel_values.js
+++ b/lib/handlers/promlabel_values.js
@@ -1,0 +1,32 @@
+/* Label Value Handler */
+/*
+   For retrieving the label values one can query on.
+   Responses looks like this:
+  {
+  "values": [
+    "default",
+    "cortex-ops",
+    ...
+  ]
+}
+*/
+
+const clickhouse = require('../db/clickhouse')
+const Sql = require('@cloki/clickhouse-sql')
+const utils = require('../utils')
+
+async function handler (req, res) {
+  req.log.debug(`GET /api/prom/label/${req.params.name}/values`)
+  let where = [
+    `key = ${Sql.val(req.params.name)}`,
+    null, //req.query.start && !isNaN(parseInt(req.query.start)) ? `date >= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.start)}, 1000000000)))` : null,
+    null, // req.query.end && !isNaN(parseInt(req.query.end)) ? `date <= toDate(FROM_UNIXTIME(intDiv(${parseInt(req.query.end)}, 1000000000)))` : null
+  ].filter(w => w)
+  where = `WHERE ${where.join(' AND ')}`
+  const q = `SELECT DISTINCT val FROM time_series_gin ${where} FORMAT JSON`
+  const allValues = await clickhouse.rawRequest(q, null, utils.DATABASE_NAME())
+  const resp = { status: 'success', data: allValues.data.data.map(r => r.val) }
+  res.send(resp)
+}
+
+module.exports = handler

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@apla/clickhouse": "^1.6.4",
         "@cloki/clickhouse-sql": "1.2.2",
         "@qxip/plugnplay": "^3.3.1",
+        "@qxip/promql2logql": "^1.0.3",
         "axios": "^0.21.4",
         "bnf": "^1.0.1",
         "date-fns": "^2.27.0",
@@ -45,7 +46,8 @@
         "yaml": "^1.10.2"
       },
       "bin": {
-        "cloki": "cloki.js"
+        "cloki": "qryn.js",
+        "qryn": "qryn.js"
       },
       "devDependencies": {
         "casual": "^1.6.2",
@@ -1343,6 +1345,26 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@qxip/promql-parser-js": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@qxip/promql-parser-js/-/promql-parser-js-0.1.1.tgz",
+      "integrity": "sha512-/jEZBk7I3oH3ETTSWKaYbHSNkMVkOFouQmYEOiesz4wBPTPRKedLYO808hh2wAUzv8lUqluMY53dRhXyk0ZAZg=="
+    },
+    "node_modules/@qxip/promql2logql": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@qxip/promql2logql/-/promql2logql-1.0.3.tgz",
+      "integrity": "sha512-phcI012MxbxXsfGAYS4aNtzPBfXMXa88J48ylry2pL55yRK20bx2Mjs0WP5LjqxlnGgfim3p9Wnn8zyCZ1zGdw==",
+      "dependencies": {
+        "@qxip/promql-parser-js": "^0.1.1",
+        "jsonic": "^1.0.1",
+        "squirrelly": "^8.0.8"
+      }
+    },
+    "node_modules/@qxip/promql2logql/node_modules/jsonic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/jsonic/-/jsonic-1.0.1.tgz",
+      "integrity": "sha512-6GitEN4plTuB/I1o9kDZl7Pgc+DvFG1BG88IqaUz4eQglCA1uAgxWdXhLNA6ffaYsmzPjOysDpp6CYTwRiuXLw=="
     },
     "node_modules/@qxip/to-file": {
       "version": "0.2.1",
@@ -10490,6 +10512,17 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "node_modules/squirrelly": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/squirrelly/-/squirrelly-8.0.8.tgz",
+      "integrity": "sha512-7dyZJ9Gw86MmH0dYLiESsjGOTj6KG8IWToTaqBuB6LwPI+hyNb6mbQaZwrfnAQ4cMDnSWMUvX/zAYDLTSWLk/w==",
+      "engines": {
+        "node": ">=6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/squirrellyjs/squirrelly?sponsor=1"
+      }
+    },
     "node_modules/stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -11566,6 +11599,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/uglify-js": {
@@ -13065,6 +13112,28 @@
         "pify": "^4.0.0",
         "require-subvert": "^0.1.0",
         "rimraf": "^3.0.2"
+      }
+    },
+    "@qxip/promql-parser-js": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@qxip/promql-parser-js/-/promql-parser-js-0.1.1.tgz",
+      "integrity": "sha512-/jEZBk7I3oH3ETTSWKaYbHSNkMVkOFouQmYEOiesz4wBPTPRKedLYO808hh2wAUzv8lUqluMY53dRhXyk0ZAZg=="
+    },
+    "@qxip/promql2logql": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@qxip/promql2logql/-/promql2logql-1.0.3.tgz",
+      "integrity": "sha512-phcI012MxbxXsfGAYS4aNtzPBfXMXa88J48ylry2pL55yRK20bx2Mjs0WP5LjqxlnGgfim3p9Wnn8zyCZ1zGdw==",
+      "requires": {
+        "@qxip/promql-parser-js": "^0.1.1",
+        "jsonic": "^1.0.1",
+        "squirrelly": "^8.0.8"
+      },
+      "dependencies": {
+        "jsonic": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/jsonic/-/jsonic-1.0.1.tgz",
+          "integrity": "sha512-6GitEN4plTuB/I1o9kDZl7Pgc+DvFG1BG88IqaUz4eQglCA1uAgxWdXhLNA6ffaYsmzPjOysDpp6CYTwRiuXLw=="
+        }
       }
     },
     "@qxip/to-file": {
@@ -20136,6 +20205,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "squirrelly": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/squirrelly/-/squirrelly-8.0.8.tgz",
+      "integrity": "sha512-7dyZJ9Gw86MmH0dYLiESsjGOTj6KG8IWToTaqBuB6LwPI+hyNb6mbQaZwrfnAQ4cMDnSWMUvX/zAYDLTSWLk/w=="
+    },
     "stack-utils": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.5.tgz",
@@ -20954,6 +21028,13 @@
           }
         }
       }
+    },
+    "typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "peer": true
     },
     "uglify-js": {
       "version": "3.14.4",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.4"
+    "@qxip/promql2logql": "^1.0.5"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.3"
+    "@qxip/promql2logql": "^1.0.4"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.2"
+    "@qxip/promql2logql": "^1.0.3"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.8"
+    "@qxip/promql2logql": "^1.0.10"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "ws": "^8.4.0",
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
-    "json-stable-stringify": "^1.0.1"
+    "json-stable-stringify": "^1.0.1",
+    "@qxip/promql2logql": "^1.0.1"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.5"
+    "@qxip/promql2logql": "^1.0.6"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.6"
+    "@qxip/promql2logql": "^1.0.8"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/promql2logql": "^1.0.1"
+    "@qxip/promql2logql": "^1.0.2"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/qryn.js
+++ b/qryn.js
@@ -392,6 +392,8 @@ fastify.post('/api/prom/remote/write', require('./lib/handlers/prom_push.js').bi
 /* PROMQETHEUS API EMULATION */
 const handlerPromQueryRange = require('./lib/handlers/prom_query_range.js').bind(this)
 fastify.get('/api/v1/query_range', handlerPromQueryRange)
+const handlerPromQuery = require('./lib/handlers/prom_query.js').bind(this)
+fastify.get('/api/v1/query', handlerPromQuery)
 fastify.get('/api/v1/labels', handlerLabel) // piggyback on qryn labels
 fastify.get('/api/v1/label/:name/values', handlerLabelValues) // piggyback on qryn values
 

--- a/qryn.js
+++ b/qryn.js
@@ -396,7 +396,8 @@ const handlerPromQuery = require('./lib/handlers/prom_query.js').bind(this)
 fastify.get('/api/v1/query', handlerPromQuery)
 fastify.get('/api/v1/labels', handlerLabel) // piggyback on qryn labels
 fastify.get('/api/v1/label/:name/values', handlerLabelValues) // piggyback on qryn values
-
+fastify.post('/api/v1/labels', handlerLabel) // piggyback on qryn labels
+fastify.post('/api/v1/label/:name/values', handlerLabelValues) // piggyback on qryn values
 
 /* QRYN-VIEW Optional Handler */
 if (fs.existsSync(path.join(__dirname, 'view/index.html'))) {

--- a/qryn.js
+++ b/qryn.js
@@ -394,10 +394,18 @@ const handlerPromQueryRange = require('./lib/handlers/prom_query_range.js').bind
 fastify.get('/api/v1/query_range', handlerPromQueryRange)
 const handlerPromQuery = require('./lib/handlers/prom_query.js').bind(this)
 fastify.get('/api/v1/query', handlerPromQuery)
-fastify.get('/api/v1/labels', handlerLabel) // piggyback on qryn labels
-fastify.get('/api/v1/label/:name/values', handlerLabelValues) // piggyback on qryn values
-fastify.post('/api/v1/labels', handlerLabel) // piggyback on qryn labels
-fastify.post('/api/v1/label/:name/values', handlerLabelValues) // piggyback on qryn values
+const handlerPromLabel = require('./lib/handlers/promlabel.js').bind(this)
+const handlerPromLabelValues = require('./lib/handlers/promlabel_values.js').bind(this)
+fastify.get('/api/v1/labels', handlerPromLabel) // piggyback on qryn labels
+fastify.get('/api/v1/label/:name/values', handlerPromLabelValues) // piggyback on qryn values
+fastify.post('/api/v1/labels', handlerPromLabel) // piggyback on qryn labels
+fastify.post('/api/v1/label/:name/values', handlerPromLabelValues) // piggyback on qryn values
+const handlerPromDefault = require('./lib/handlers/prom_default.js').bind(this)
+fastify.post('/api/v1/metadata', handlerPromDefault) // default handler TBD
+fastify.post('/api/v1/rules', handlerPromDefault) // default handler TBD
+fastify.post('/api/v1/query_exemplars', handlerPromDefault) // default handler TBD
+fastify.post('/api/v1/status/buildinfo', handlerPromDefault) // default handler TBD
+
 
 /* QRYN-VIEW Optional Handler */
 if (fs.existsSync(path.join(__dirname, 'view/index.html'))) {

--- a/qryn.js
+++ b/qryn.js
@@ -389,6 +389,13 @@ fastify.get('/prometheus/api/v1/rules', require('./lib/handlers/alerts/prom_get_
 fastify.post('/api/v1/prom/remote/write', require('./lib/handlers/prom_push.js').bind(this))
 fastify.post('/api/prom/remote/write', require('./lib/handlers/prom_push.js').bind(this))
 
+/* PROMQETHEUS API EMULATION */
+const handlerPromQueryRange = require('./lib/handlers/prom_query_range.js').bind(this)
+fastify.get('/api/v1/query_range', handlerPromQueryRange)
+fastify.get('/api/v1/labels', handlerLabel) // piggyback on qryn labels
+fastify.get('/api/v1/label/:name/values', handlerLabelValues) // piggyback on qryn values
+
+
 /* QRYN-VIEW Optional Handler */
 if (fs.existsSync(path.join(__dirname, 'view/index.html'))) {
   fastify.register(require('fastify-static'), {

--- a/qryn.js
+++ b/qryn.js
@@ -401,10 +401,10 @@ fastify.get('/api/v1/label/:name/values', handlerPromLabelValues) // piggyback o
 fastify.post('/api/v1/labels', handlerPromLabel) // piggyback on qryn labels
 fastify.post('/api/v1/label/:name/values', handlerPromLabelValues) // piggyback on qryn values
 const handlerPromDefault = require('./lib/handlers/prom_default.js').bind(this)
-fastify.post('/api/v1/metadata', handlerPromDefault) // default handler TBD
-fastify.post('/api/v1/rules', handlerPromDefault) // default handler TBD
-fastify.post('/api/v1/query_exemplars', handlerPromDefault) // default handler TBD
-fastify.post('/api/v1/status/buildinfo', handlerPromDefault) // default handler TBD
+fastify.get('/api/v1/metadata', handlerPromDefault) // default handler TBD
+fastify.get('/api/v1/rules', handlerPromDefault) // default handler TBD
+fastify.get('/api/v1/query_exemplars', handlerPromDefault) // default handler TBD
+fastify.get('/api/v1/status/buildinfo', handlerPromDefault) // default handler TBD
 
 
 /* QRYN-VIEW Optional Handler */


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/1423657/184315884-e2f946c2-dbc2-40de-b32c-a6876b3b46c0.png" width=200 />



## PromQL Emulation APIs
This PR implements an API set to handle and transpile simple PromQL queries into LogQL `unwrap_value` metric in qryn

##### Status: Experimental, working!

#### About
The [WASM parser](https://github.com/lmangani/rust-promql-parser-js) and [sqrl transpiler](https://github.com/lmangani/promql2logql) templates only support extremely basic queries, ie:
* Input: ```rate(foo{"bar"="baz")[5m]) by (x,y)```
* Output: ```rate({"__name__"="foo", "bar"="baz"} | unwrap_value [300s]) by (x,y)```

##### Endpoints
- [x] `fastify.get('/api/v1/query_range', handlerPromQueryRange)`
- [x] `fastify.get('/api/v1/query', handlerPromQuery)`
- [x] `fastify.get('/api/v1/labels', handlerPromLabel) // piggyback on qryn labels`
- [x] `fastify.get('/api/v1/label/:name/values', handlerPromLabelValues) // piggyback on qryn values`
- [x] `fastify.post('/api/v1/labels', handlerPromLabel) // piggyback on qryn labels`
- [x] `fastify.post('/api/v1/label/:name/values', handlerPromLabelValues) // piggyback on qryn values`
- [x] `fastify.get('/api/v1/metadata', handlerPromDefault) // default handler TBD`
- [x] `fastify.get('/api/v1/rules', handlerPromDefault) // default handler TBD`
- [x] `fastify.get('/api/v1/query_exemplars', handlerPromDefault) // default handler TBD`
- [x] `fastify.get('/api/v1/status/buildinfo', handlerPromDefault) // default handler TBD`

#### Issues
- [x] Adjust start/stop timestamp format to match LogQL API requirements
- [x] Adjust response format to match PromQL requirements

#### References
* [Prometheus querying API](https://prometheus.io/docs/prometheus/latest/querying/api/)
* [promql2logql](https://github.com/lmangani/promql2logql)
* [promql-parser-js](https://github.com/lmangani/rust-promql-parser-js)