### PR TITLE
Influx line protocol /write API

### DIFF
--- a/lib/handlers/influx_push.js
+++ b/lib/handlers/influx_push.js
@@ -1,0 +1,146 @@
+/* Influx Line protocol Write Handler for Qryn */
+/*
+   Accepts Line protocols parsed by @qxip/influx-line-protocol-parser
+   
+   /* metrics */
+   {
+     measurement: 'cpu_load_short',
+     timestamp: 1422568543702900257,
+     fields: [{
+        value: 2
+     }],
+     tags:[
+        {direction: 'in'},
+        {host: 'server01'},
+        {region: 'us-west'},
+     ]
+   }
+   
+   /* syslog */
+   {
+     measurement:"syslog",
+     fields:[
+        {facility_code: 14},
+        {message: "warning message here"},
+        {severity_code: 4},
+        {procid: "12345"},
+        {timestamp: 1534418426076077000},
+        {version: 1}
+     ],
+     tags:[
+        {appname: "myapp"},
+        {facility: "console"},
+        {host: "myhost"},
+        {hostname: "myhost"},
+        {severity: "warning"}
+     ]
+   }
+   
+   
+*/
+const stringify = require('../utils').stringify
+var lineToJSON = require('@qxip/influx-line-protocol-parser');
+
+function handler (req, res) {
+  req.log.error('POST /influx')
+  if (!req.body && !req.body.metrics) {
+    req.log.error('No Request Body!')
+    return
+  }
+  if (this.readonly) {
+    req.log.error('Readonly! No push support.')
+    res.send(500)
+    return
+  }
+  let streams
+  try {
+    streams = lineToJSON(req.body);
+  } catch(e) { streams = []; }
+  
+  if (!Array.isArray(streams)) streams = [streams]
+  if (streams) {
+    req.log.debug({ streams }, 'influx')
+    streams.forEach(function (stream) {
+      let JSONLabels = {};
+      let JSONFields = {};
+      let finger = null
+      try {
+        if (stream.tags){
+          stream.tags.forEach(function (tag) {
+            Object.assign(JSONLabels, tag);
+          })
+        }
+        if (stream.fields){
+          stream.fields.forEach(function (field) {
+            Object.assign(JSONFields, field);
+          })
+        }
+        JSONLabels['__name__'] = stream.measurement || 'null'
+        // Calculate Fingerprint
+        const strLabels = stringify(Object.fromEntries(Object.entries(JSONLabels).sort()))
+        finger = this.fingerPrint(strLabels)
+        req.log.debug({ JSONLabels, finger }, 'LABELS FINGERPRINT')
+        this.labels.add(finger.toString(), stream.labels)
+        // Store Fingerprint
+        this.bulk_labels.add(finger.toString(), [
+          new Date().toISOString().split('T')[0],
+          finger,
+          strLabels,
+          stream.measurement || ''
+        ])
+        for (const key in JSONLabels) {
+          // req.log.debug({ key, data: JSONLabels[key] }, 'Storing label');
+          this.labels.add('_LABELS_', key)
+          this.labels.add(key, JSONLabels[key])
+        }
+      } catch (err) {
+        req.log.error({ err })
+      }
+      /* metrics */
+      if (stream.fields && stream.measurement != "syslog") {
+        for (const [key, value] of Object.entries(JSONFields)) {
+          // req.log.debug({ key, value, finger }, 'BULK ROW');
+          if (
+            !key &&
+            !stream.timestamp &&
+            !value
+          ) {
+            req.log.error({ key }, 'no bulkable data')
+            return
+          }
+          const values = [
+            finger,
+            BigInt(pad('0000000000000000000',stream.timestamp,true)),
+            value || 0,
+            key || ''
+          ]
+          this.bulk.add(values)
+        }
+      /* logs or syslog */  
+      } else if (stream.measurement == "syslog" || JSONFields.message){
+          // Send fields as a JSON object for qryn to parse
+          const message = JSON.stringify(JSONFields);
+          const values = [
+            finger,
+            BigInt(pad('0000000000000000000',stream.timestamp,true)),
+            '',
+            message
+          ]
+          this.bulk.add(values)
+      }
+    })
+  }
+  res.send(200)
+}
+
+function pad(pad, str, padLeft) {
+  if (typeof str === 'undefined')
+    return pad;
+  if (padLeft) {
+    return (pad + str).slice(-pad.length);
+  } else {
+    return (str + pad).substring(0, pad.length);
+  }
+}
+
+module.exports = handler

--- a/lib/handlers/influx_write.js
+++ b/lib/handlers/influx_write.js
@@ -2,7 +2,6 @@
 /*
    Accepts Line protocols parsed by @qxip/influx-line-protocol-parser
    
-   /* metrics */
    {
      measurement: 'cpu_load_short',
      timestamp: 1422568543702900257,
@@ -16,7 +15,6 @@
      ]
    }
    
-   /* syslog */
    {
      measurement:"syslog",
      fields:[
@@ -36,8 +34,8 @@
      ]
    }
    
-   
 */
+
 const stringify = require('../utils').stringify
 var lineToJSON = require('@qxip/influx-line-protocol-parser');
 

--- a/lib/handlers/influx_write.js
+++ b/lib/handlers/influx_write.js
@@ -37,65 +37,69 @@
 */
 
 const stringify = require('../utils').stringify
-var lineToJSON = require('@qxip/influx-line-protocol-parser');
+const lineToJSON = require('@qxip/influx-line-protocol-parser')
 
 function handler (req, res) {
+  const self = this
   req.log.error('POST INFLUX /write')
   if (!req.body && !req.body.metrics) {
     req.log.error('No Request Body!')
     return
   }
-  if (this.readonly) {
+  if (self.readonly) {
     req.log.error('Readonly! No push support.')
     res.send(500)
     return
   }
   let streams
   try {
-    streams = lineToJSON(req.body);
-  } catch(e) { streams = []; }
-  
+    streams = lineToJSON(req.body)
+  } catch (e) {
+    streams = []
+  }
   if (!Array.isArray(streams)) streams = [streams]
   if (streams) {
     req.log.debug({ streams }, 'influx')
+
     streams.forEach(function (stream) {
-      let JSONLabels = {};
-      let JSONFields = {};
+      const JSONLabels = {}
+      const JSONFields = {}
       let finger = null
       try {
-        if (stream.tags){
+        if (stream.tags) {
           stream.tags.forEach(function (tag) {
-            Object.assign(JSONLabels, tag);
+            Object.assign(JSONLabels, tag)
           })
         }
-        if (stream.fields){
+        if (stream.fields) {
+          console.log(stream.fields)
           stream.fields.forEach(function (field) {
-            Object.assign(JSONFields, field);
+            Object.assign(JSONFields, field)
           })
         }
-        JSONLabels['__name__'] = stream.measurement || 'null'
+        JSONLabels.__name__ = stream.measurement || 'null'
         // Calculate Fingerprint
         const strLabels = stringify(Object.fromEntries(Object.entries(JSONLabels).sort()))
-        finger = this.fingerPrint(strLabels)
+        finger = self.fingerPrint(strLabels)
         req.log.debug({ JSONLabels, finger }, 'LABELS FINGERPRINT')
-        this.labels.add(finger.toString(), stream.labels)
+        self.labels.add(finger.toString(), stream.labels)
         // Store Fingerprint
-        this.bulk_labels.add(finger.toString(), [
+        self.bulk_labels.add([[
           new Date().toISOString().split('T')[0],
           finger,
           strLabels,
           stream.measurement || ''
-        ])
+        ]])
         for (const key in JSONLabels) {
           // req.log.debug({ key, data: JSONLabels[key] }, 'Storing label');
-          this.labels.add('_LABELS_', key)
-          this.labels.add(key, JSONLabels[key])
+          self.labels.add('_LABELS_', key)
+          self.labels.add(key, JSONLabels[key])
         }
       } catch (err) {
         req.log.error({ err })
       }
       /* metrics */
-      if (stream.fields && stream.measurement != "syslog" && !JSONFields.message) {
+      if (stream.fields && stream.measurement !== 'syslog' && !JSONFields.message) {
         for (const [key, value] of Object.entries(JSONFields)) {
           // req.log.debug({ key, value, finger }, 'BULK ROW');
           if (
@@ -108,36 +112,37 @@ function handler (req, res) {
           }
           const values = [
             finger,
-            BigInt(pad('0000000000000000000',stream.timestamp,true)),
+            BigInt(pad('0000000000000000000', stream.timestamp, true)),
             value || 0,
             key || ''
           ]
-          this.bulk.add(values)
+          self.bulk.add([values])
         }
-      /* logs or syslog */  
-      } else if (stream.measurement == "syslog" || JSONFields.message){
-          // Send fields as a JSON object for qryn to parse
-          const message = JSON.stringify(JSONFields);
-          const values = [
-            finger,
-            BigInt(pad('0000000000000000000',stream.timestamp,true)),
-            '',
-            message
-          ]
-          this.bulk.add(values)
+      /* logs or syslog */
+      } else if (stream.measurement === 'syslog' || JSONFields.message) {
+        // Send fields as a JSON object for qryn to parse
+        // const message = JSON.stringify(JSONFields)
+        const values = [
+          finger,
+          BigInt(pad('0000000000000000000', stream.timestamp, true)),
+          null,
+          JSONFields.message
+        ]
+        self.bulk.add([values])
       }
     })
   }
   res.send(200)
 }
 
-function pad(pad, str, padLeft) {
-  if (typeof str === 'undefined')
-    return pad;
+function pad (pad, str, padLeft) {
+  if (typeof str === 'undefined') {
+    return pad
+  }
   if (padLeft) {
-    return (pad + str).slice(-pad.length);
+    return (pad + str).slice(-pad.length)
   } else {
-    return (str + pad).substring(0, pad.length);
+    return (str + pad).substring(0, pad.length)
   }
 }
 

--- a/lib/handlers/influx_write.js
+++ b/lib/handlers/influx_write.js
@@ -42,7 +42,7 @@ const stringify = require('../utils').stringify
 var lineToJSON = require('@qxip/influx-line-protocol-parser');
 
 function handler (req, res) {
-  req.log.error('POST /influx')
+  req.log.error('POST INFLUX /write')
   if (!req.body && !req.body.metrics) {
     req.log.error('No Request Body!')
     return

--- a/lib/handlers/influx_write.js
+++ b/lib/handlers/influx_write.js
@@ -95,7 +95,7 @@ function handler (req, res) {
         req.log.error({ err })
       }
       /* metrics */
-      if (stream.fields && stream.measurement != "syslog") {
+      if (stream.fields && stream.measurement != "syslog" && !JSONFields.message) {
         for (const [key, value] of Object.entries(JSONFields)) {
           // req.log.debug({ key, value, finger }, 'BULK ROW');
           if (

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
     "json-stable-stringify": "^1.0.1",
-    "@qxip/influx-line-protocol-parser", "^0.2.1"
+    "@qxip/influx-line-protocol-parser": "^0.2.1"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "ws": "^8.4.0",
     "xxhash-wasm": "^0.4.2",
     "yaml": "^1.10.2",
-    "json-stable-stringify": "^1.0.1"
+    "json-stable-stringify": "^1.0.1",
+    "@qxip/influx-line-protocol-parser", "^0.2.1"
   },
   "devDependencies": {
     "casual": "^1.6.2",

--- a/qryn.js
+++ b/qryn.js
@@ -391,8 +391,8 @@ fastify.post('/api/prom/remote/write', require('./lib/handlers/prom_push.js').bi
 
 /* INFLUX WRITE Handlers */
 const handlerInfluxWrite = require('./lib/handlers/influx_write.js').bind(this)
-fastify.post('/write', handlerInfluxWrite).bind(this))
-fastify.post('/influx/write', handlerInfluxWrite).bind(this))
+fastify.post('/write', handlerInfluxWrite)
+fastify.post('/influx/write', handlerInfluxWrite)
 
 /* QRYN-VIEW Optional Handler */
 if (fs.existsSync(path.join(__dirname, 'view/index.html'))) {

--- a/qryn.js
+++ b/qryn.js
@@ -389,6 +389,11 @@ fastify.get('/prometheus/api/v1/rules', require('./lib/handlers/alerts/prom_get_
 fastify.post('/api/v1/prom/remote/write', require('./lib/handlers/prom_push.js').bind(this))
 fastify.post('/api/prom/remote/write', require('./lib/handlers/prom_push.js').bind(this))
 
+/* INFLUX WRITE Handlers */
+const handlerInfluxWrite = require('./lib/handlers/influx_write.js').bind(this)
+fastify.post('/write', handlerInfluxWrite).bind(this))
+fastify.post('/influx/write', handlerInfluxWrite).bind(this))
+
 /* QRYN-VIEW Optional Handler */
 if (fs.existsSync(path.join(__dirname, 'view/index.html'))) {
   fastify.register(require('fastify-static'), {

--- a/qryn.js
+++ b/qryn.js
@@ -392,7 +392,7 @@ fastify.post('/api/prom/remote/write', require('./lib/handlers/prom_push.js').bi
 /* INFLUX WRITE Handlers */
 const handlerInfluxWrite = require('./lib/handlers/influx_write.js').bind(this)
 fastify.post('/write', handlerInfluxWrite)
-fastify.post('/influx/write', handlerInfluxWrite)
+fastify.post('/influx/api/v2/write', handlerInfluxWrite)
 
 /* QRYN-VIEW Optional Handler */
 if (fs.existsSync(path.join(__dirname, 'view/index.html'))) {


### PR DESCRIPTION
## Influx lineprotocol /write API
This PR implements an API set to handle Influx line protocol inserts into generic `unwrap_value` metric in qryn

##### Status: Experimental

#### Endpoints
* `/influx/api/v2/write` _accepts single line protocol inserts via `POST`

#### Usage

##### CURL
```
curl -i -XPOST 'http://localhost:3100/influx/api/v2/write' \
  --data-raw 'cpu_load_short,host=server01,region=us-west value=0.64 1434055562000000000'
```
```
curl -i -XPOST 'http://localhost:3100/influx/api/v2/write' \
  --data-raw 'syslog,appname=myapp,facility=console,host=myhost,hostname=myhost,severity=warning facility_code=14i,message="warning message here",severity_code=4i,procid="12345",timestamp=1434055562000000000,version=1'
```
##### ClickHouse MV _(working sketch)_
```
CREATE MATERIALIZED VIEW default.influx_log_send
ENGINE = URL('http://localhost:3100/influx/api/v2/write', 'LineAsString')
AS SELECT format('syslog,level={0},logger_name={1} message="{2}" {3}', 
  toString(level), 
  replaceRegexpAll(toString(logger_name), '[^a-zA-Z0-9_]', '_'), 
  replaceAll(replaceRegexpAll(message, '["\\\\]', '\x00\\0'), '\x00', '\\'), 
  toString(toUnixTimestamp64Nano(event_time_microseconds))) FROM system.text_log;
```