### PR TITLE
configurable primary key for the samples table

### DIFF
--- a/common.js
+++ b/common.js
@@ -82,3 +82,18 @@ module.exports.durationToNs = (durationStr) => {
 module.exports.LineFmtOption = () => process.env.LINE_FMT || 'handlebars'
 
 module.exports.errors = require('./lib/handlers/errors')
+/**
+ * @returns {string}
+ */
+module.exports.samplesOrderingRule = () => {
+  return process.env.ADVANCED_SAMPLES_ORDERING
+    ? process.env.ADVANCED_SAMPLES_ORDERING
+    : 'timestamp_ns'
+}
+
+/**
+ * @returns {boolean}
+ */
+module.exports.isCustomSamplesOrderingRule = () => {
+  return process.env.ADVANCED_SAMPLES_ORDERING && process.env.ADVANCED_SAMPLES_ORDERING !== 'timestamp_ns'
+}

--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -38,7 +38,7 @@ const storagePolicy = process.env.STORAGE_POLICY || false
 
 const { StringStream, DataStream } = require('scramjet')
 
-const { parseLabels, hashLabels } = require('../../common')
+const { parseLabels, hashLabels, isCustomSamplesOrderingRule } = require('../../common')
 
 const { Worker, isMainThread } = require('worker_threads')
 
@@ -170,7 +170,7 @@ const checkCapabilities = async () => {
   try {
     await axios.post(getClickhouseUrl() + '/?allow_experimental_live_view=1',
       `CREATE LIVE VIEW ${clickhouseOptions.queryOptions.database}.lvcheck WITH TIMEOUT 1 AS SELECT 1`)
-    capabilities.liveView = true
+    capabilities.liveView = !isCustomSamplesOrderingRule()
     logger.info('LIVE VIEW: supported')
   } catch (e) {
     logger.info('LIVE VIEW: unsupported')

--- a/lib/db/maintain/index.js
+++ b/lib/db/maintain/index.js
@@ -1,6 +1,7 @@
 const hb = require('handlebars')
 const client = require('../clickhouse')
 const logger = require('../../logger')
+const {samplesOrderingRule} = require('../../../common')
 const getEnv = () => {
   return {
     CLICKHOUSE_DB: 'cloki',
@@ -37,8 +38,8 @@ const upgradeSingle = async (db, key, scripts) => {
     if (!scripts[i]) { continue }
     scripts[i] = scripts[i].trim()
     const tpl = hb.compile(scripts[i])
-    scripts[i] = tpl({ ...getEnv(), DB: db })
-    console.log(`v${i} -> v${i+1}`)
+    scripts[i] = tpl({ ...getEnv(), DB: db, SAMPLES_ORDER_RUL: samplesOrderingRule() })
+    console.log(`v${i} -> v${i + 1}`)
     console.log(scripts[i])
     await client.rawRequest(scripts[i], null, db)
     await client.rawRequest(`INSERT INTO ver (k, ver) VALUES (${key}, ${i + 1})`, null, db)

--- a/lib/db/maintain/scripts.js
+++ b/lib/db/maintain/scripts.js
@@ -10,7 +10,7 @@ module.exports.overall = [
       string String
     ) ENGINE = MergeTree
     PARTITION BY toStartOfDay(toDateTime(timestamp_ns / 1000000000))
-    ORDER BY (timestamp_ns)`,
+    ORDER BY ({{SAMPLES_ORDER_RUL}})`,
 
   `CREATE TABLE IF NOT EXISTS settings
     (fingerprint UInt64, type String, name String, value String, inserted_at DateTime64(9, 'UTC'))


### PR DESCRIPTION
Please specify the `ADVANCED_SAMPLES_ORDERING` env var with the raw clickhouse ORDER BY (...) experssion.
If you want use fingerprint, please specify `ADVANCED_SAMPLES_ORDERING=fingerprint,timestamp_ns` . 
This env variable cannot be changed for the same database.
If you specified this configuration, no samples primary key updates will be applied for the database in the future.
Please use it with care.