### PR TITLE
limit 2000 spans to get from the huge trace

### DIFF
--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -280,7 +280,7 @@ const tempoQueryScanV1 = async function (query, res, traceId) {
 const tempoQueryScanV2 = async function (query, res, traceId) {
   logger.debug(`Scanning Tempo Fingerprints... ${traceId}`)
   const _stream = await axios.post(getClickhouseUrl() + '/',
-    `SELECT payload_type, payload FROM ${DATABASE_NAME()}.tempo_traces WHERE oid='0' AND trace_id=unhex('${traceId}') FORMAT JSONEachRow`,
+    `SELECT payload_type, payload FROM ${DATABASE_NAME()}.tempo_traces WHERE oid='0' AND trace_id=unhex('${traceId}') ORDER BY timestamp_ns ASC LIMIT 2000 FORMAT JSONEachRow`,
     {
       responseType: 'stream'
     }


### PR DESCRIPTION
According to https://github.com/metrico/qryn/issues/231 :
Add limit to no more than 2000 spans for one trace.