### PR TITLE
Elastic JSON ingestion

### DIFF
--- a/lib/handlers/elastic_index.js
+++ b/lib/handlers/elastic_index.js
@@ -75,7 +75,7 @@ function handler (req, res) {
       }
 
       try {
-        stream = JSON.parse(JSON.stringify(stream))
+        stream = JSON.parse(stream);
       } catch (err) { req.log.error({ err }); return };
       // Store Elastic Doc Object
       const values = [


### PR DESCRIPTION
Fixing the Elastic Index API JSON ingestor to not double-parse objects

Signed-off-by: Lorenzo Mangani <lorenzo.mangani@gmail.com>