### PR TITLE
Newrelic Log Ingestion Handler

### DIFF
--- a/lib/handlers/newrelic_log_push.js
+++ b/lib/handlers/newrelic_log_push.js
@@ -1,0 +1,114 @@
+/*  New Relic Log Ingestor (https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/)
+
+    Accepts JSON formatted requests when the header Content-Type: application/json is sent.
+    Example of the JSON format:
+
+    POST /log/v1 HTTP/1.1
+    Host: log-api.newrelic.com
+    Content-Type: application/json
+    Api-Key: <YOUR_LICENSE_KEY>
+    Accept: */*
+    Content-Length: 319
+    [{
+       "common": {
+         "attributes": {
+           "logtype": "accesslogs",
+           "service": "login-service",
+           "hostname": "login.example.com"
+         }
+       },
+       "logs": [{
+           "timestamp": <TIMESTAMP_IN_UNIX_EPOCH><,
+           "message": "User 'xyz' logged in"
+         },{
+           "timestamp": <TIMESTAMP_IN_UNIX_EPOCH,
+           "message": "User 'xyz' logged out",
+           "attributes": {
+             "auditId": 123
+           }
+         }]
+    }]
+*/
+
+const stringify = require('../utils').stringify
+
+function handler (req, res) {
+  const self = this
+  req.log.debug('NewRelic Log Index Request')
+  if (!req.body || !req.params.target) {
+    req.log.error('No Request Body or Target!')
+    res.code(400).send('{"status":400, "error": { "reason": "No Request Body" } }')
+    return
+  }
+  if (this.readonly) {
+    req.log.error('Readonly! No push support.')
+    res.code(400).send('{"status":400, "error": { "reason": "Read Only Mode" } }')
+    return
+  }
+  
+  let streams;
+  if (Array.isArray(req.body)){
+     // Bulk Logs
+     streams = req.body 
+  } else {
+     // Single Log
+     var {timestamp, ...tags } = req.body;
+     var {message, ...tags} = tags;
+     streams = [{ 
+        attributes: tags, 
+        logs: [{ timestamp, message }]
+     }]
+  }
+  req.log.info({ streams }, 'streams')
+  if (streams) {
+    streams.forEach(function (stream) {
+      req.log.debug({ stream }, 'ingesting newrelic log')
+      let finger = null
+      let JSONLabels = stream?.common?.attributes || stream?.attributes || {}
+      try {
+        try {
+          JSONLabels.type = 'newrelic'
+          JSONLabels = Object.fromEntries(Object.entries(JSONLabels).sort())
+        } catch (err) {
+          req.log.error({ err })
+          return
+        }
+        // Calculate Fingerprint
+        const strJson = stringify(JSONLabels)
+        finger = self.fingerPrint(strJson)
+        // Store Fingerprint
+        self.bulk_labels.add([[
+          new Date().toISOString().split('T')[0],
+          finger,
+          strJson,
+          JSONLabels.target || ''
+        ]])
+        for (const key in JSONLabels) {
+          req.log.debug({ key, data: JSONLabels[key] }, 'Storing label')
+          self.labels.add('_LABELS_', key)
+          self.labels.add(key, JSONLabels[key])
+        }
+      } catch (err) {
+        req.log.error({ err }, 'failed ingesting datadog log')
+      }
+      // Queue Array logs
+      if (stream.logs) {
+        stream.logs.forEach(function (log) {
+            // Store NewRelic Log
+            // TODO: handle additional attributes!
+            const values = [
+              finger,
+              BigInt((new Date(log.timestamp).getTime() * 1000) + '000'),
+              null,
+              log.message
+            ]
+            req.log.debug({ finger, values }, 'store')
+            self.bulk.add([values])
+        })
+      }
+    })
+  }
+  res.code(200).send()
+}
+
+module.exports = handler

--- a/lib/handlers/newrelic_log_push.js
+++ b/lib/handlers/newrelic_log_push.js
@@ -7,7 +7,6 @@
     Host: log-api.newrelic.com
     Content-Type: application/json
     Api-Key: <YOUR_LICENSE_KEY>
-    Accept: */*
     Content-Length: 319
     [{
        "common": {

--- a/lib/handlers/newrelic_log_push.js
+++ b/lib/handlers/newrelic_log_push.js
@@ -29,36 +29,43 @@
     }]
 */
 
+const { QrynBadRequest } = require('./errors')
 const stringify = require('../utils').stringify
 
-function handler (req, res) {
+async function handler (req, res) {
   const self = this
   req.log.debug('NewRelic Log Index Request')
-  if (!req.body || !req.params.target) {
-    req.log.error('No Request Body or Target!')
-    res.code(400).send('{"status":400, "error": { "reason": "No Request Body" } }')
-    return
+  if (!req.body) {
+    req.log.error('No Request Body')
+    throw new QrynBadRequest('No request body')
   }
   if (this.readonly) {
     req.log.error('Readonly! No push support.')
-    res.code(400).send('{"status":400, "error": { "reason": "Read Only Mode" } }')
-    return
+    throw new QrynBadRequest('Read only mode')
   }
-  
-  let streams;
-  if (Array.isArray(req.body)){
-     // Bulk Logs
-     streams = req.body 
+  let streams
+  if (Array.isArray(req.body)) {
+    // Bulk Logs
+    streams = req.body
   } else {
-     // Single Log
-     var {timestamp, ...tags } = req.body;
-     var {message, ...tags} = tags;
-     streams = [{ 
-        attributes: tags, 
-        logs: [{ timestamp, message }]
-     }]
+    // Single Log
+    const tags = req.body
+    const { timestamp, message } = tags
+    if (!timestamp) {
+      throw new QrynBadRequest('Log timestamp is undefined')
+    }
+    if (!message) {
+      throw new QrynBadRequest('Log message is undefined')
+    }
+    delete tags.message
+    delete tags.timestamp
+    streams = [{
+      common: { attributes: tags },
+      logs: [{ timestamp, message }]
+    }]
   }
   req.log.info({ streams }, 'streams')
+  const promises = []
   if (streams) {
     streams.forEach(function (stream) {
       req.log.debug({ stream }, 'ingesting newrelic log')
@@ -76,12 +83,12 @@ function handler (req, res) {
         const strJson = stringify(JSONLabels)
         finger = self.fingerPrint(strJson)
         // Store Fingerprint
-        self.bulk_labels.add([[
+        promises.push(self.bulk_labels.add([[
           new Date().toISOString().split('T')[0],
           finger,
           strJson,
           JSONLabels.target || ''
-        ]])
+        ]]))
         for (const key in JSONLabels) {
           req.log.debug({ key, data: JSONLabels[key] }, 'Storing label')
           self.labels.add('_LABELS_', key)
@@ -93,21 +100,21 @@ function handler (req, res) {
       // Queue Array logs
       if (stream.logs) {
         stream.logs.forEach(function (log) {
-            // Store NewRelic Log
-            // TODO: handle additional attributes!
-            const values = [
-              finger,
-              BigInt((new Date(log.timestamp).getTime() * 1000) + '000'),
-              null,
-              log.message
-            ]
-            req.log.debug({ finger, values }, 'store')
-            self.bulk.add([values])
+          // Store NewRelic Log
+          // TODO: handle additional attributes!
+          const values = [
+            finger,
+            BigInt(`${log.timestamp}0000000000000000000`.substring(0, 19)),
+            null,
+            log.message
+          ]
+          promises.push(self.bulk.add([values]))
         })
       }
     })
   }
-  res.code(200).send()
+  await Promise.all(promises)
+  res.code(200).send('OK')
 }
 
 module.exports = handler

--- a/qryn.js
+++ b/qryn.js
@@ -326,6 +326,12 @@ fastify.get('/api/v1/rules', handlerPromDefault) // default handler TBD
 fastify.get('/api/v1/query_exemplars', handlerPromDefault) // default handler TBD
 fastify.get('/api/v1/status/buildinfo', handlerPromDefault) // default handler TBD
 
+/* NewRelic Log Handler */
+const handlerNewrelicLogPush = require('./lib/handlers/newrelic_log_push.js').bind(this)
+fastify.post('/log/v1', handlerNewrelicLogPush, {
+  '*': rawStringParser
+})
+
 /* INFLUX WRITE Handlers */
 const handlerInfluxWrite = require('./lib/handlers/influx_write.js').bind(this)
 fastify.post('/write', handlerInfluxWrite, {

--- a/qryn.js
+++ b/qryn.js
@@ -329,7 +329,7 @@ fastify.get('/api/v1/status/buildinfo', handlerPromDefault) // default handler T
 /* NewRelic Log Handler */
 const handlerNewrelicLogPush = require('./lib/handlers/newrelic_log_push.js').bind(this)
 fastify.post('/log/v1', handlerNewrelicLogPush, {
-  '*': rawStringParser
+  '*': jsonParser
 })
 
 /* INFLUX WRITE Handlers */


### PR DESCRIPTION
Simple handler to ingest New Relic JSON objects based on [documentation examples](https://docs.newrelic.com/docs/logs/log-api/introduction-log-api/)

### Log Endpoint
* [x] POST `/log/v1`

#### Example (bulk)
```
[{
   "common": {
     "attributes": {
       "logtype": "accesslogs",
       "service": "login-service",
       "hostname": "login.example.com"
     }
   },
   "logs": [{
       "timestamp": <TIMESTAMP_IN_UNIX_EPOCH><,
       "message": "User 'xyz' logged in"
     },{
       "timestamp": <TIMESTAMP_IN_UNIX_EPOCH,
       "message": "User 'xyz' logged out",
       "attributes": {
         "auditId": 123
       }
     }]
}]
```
#### Example (single)
```
{
    "timestamp": <TIMESTAMP_IN_UNIX_EPOCH>,
    "message": "User 'xyz' logged in",
    "logtype": "accesslogs",
    "service": "login-service",
    "hostname": "login.example.com"
}
```

### TODO:
- [ ] triple check everything, ie: timestamps
- [ ] add curl examples
- [ ] test with [CloudFlare Logpush](https://developers.cloudflare.com/logs/get-started/enable-destinations/new-relic/)
- [ ] add test e2e test cases