### PR TITLE
Promql non-handlers

### DIFF
--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -1,9 +1,25 @@
 /* Emulated PromQL Query Handler */
 
 async function handler (req, res) {
-  req.log.debug('GET /api/v1/*')
-  const resp = {"status": "success", "data": {}};
-  res.send(resp)
+  const path = req.urlData('path')
+  req.log.debug('PROM Handler',path)
+  switch (path) {
+    case '/api/v1/status/buildinfo':
+      res.send(
+        { "status": "success", 
+           "data": { 
+             "version": "2.13.1",
+             "revision": "cb7cbad5f9a2823a622aaa668833ca04f50a0ea7",
+             "branch": "master",
+             "buildUser": "qryn@qxip",
+             "buildDate": "29990401-13:37:420",
+             "goVersion": "go1.18.1"
+           }
+        })
+      break
+    default:
+      res.send({"status": "success", "data": {}})
+  }
   return
 }
 

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -17,6 +17,15 @@ async function handler (req, res) {
            }
         })
       break
+    case '/api/v1/rules'
+      res.send("data": {
+        "status": "success", 
+          "groups": [
+              {
+                  "rules": []
+              }
+            ]
+        })
     default:
       res.send({"status": "success", "data": {}})
   }

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -26,7 +26,8 @@ async function handler (req, res) {
                   "rules": []
               }
             ]
-        })
+        }
+      })
     default:
       res.send({"status": "success", "data": {}})
   }

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -1,7 +1,7 @@
 /* Emulated PromQL Query Handler */
 
 async function handler (req, res) {
-  const path = req.raw.url
+  const path = new Url(req.url).pathname
   req.log.debug('PROM Handler',path)
   switch (path) {
     case '/api/v1/status/buildinfo':
@@ -18,8 +18,9 @@ async function handler (req, res) {
         })
       break
     case '/api/v1/rules':
-      res.send("data": {
+      res.send({
         "status": "success", 
+        "data": {
           "groups": [
               {
                   "rules": []

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -1,7 +1,7 @@
 /* Emulated PromQL Query Handler */
 
 async function handler (req, res) {
-  const path = req.urlData('path')
+  const path = req.raw.url
   req.log.debug('PROM Handler',path)
   switch (path) {
     case '/api/v1/status/buildinfo':

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -1,37 +1,42 @@
 /* Emulated PromQL Query Handler */
 
-async function handler (req, res) {
+async function buildinfo (req, res) {
   const path = req.url
-  req.log.debug('PROM Handler',path)
-  switch (path) {
-    case '/api/v1/status/buildinfo':
-      res.send(
-        { "status": "success", 
-           "data": { 
-             "version": "2.13.1",
-             "revision": "cb7cbad5f9a2823a622aaa668833ca04f50a0ea7",
-             "branch": "master",
-             "buildUser": "qryn@qxip",
-             "buildDate": "29990401-13:37:420",
-             "goVersion": "go1.18.1"
-           }
-        })
-      break
-    case '/api/v1/rules':
-      res.send({
-        "status": "success", 
-        "data": {
-          "groups": [
-              {
-                  "rules": []
-              }
-            ]
-        }
-      })
-    default:
-      res.send({"status": "success", "data": {}})
-  }
-  return
+  req.log.debug('PROM Handler', path)
+  return res.send(
+    {
+      status: 'success',
+      data: {
+        version: '2.13.1',
+        revision: 'cb7cbad5f9a2823a622aaa668833ca04f50a0ea7',
+        branch: 'master',
+        buildUser: 'qryn@qxip',
+        buildDate: '29990401-13:37:420',
+        goVersion: 'go1.18.1'
+      }
+    })
 }
 
-module.exports = handler
+async function rules (req, res) {
+  req.log.debug('PROM Handler', req.url)
+  return res.send({
+    status: 'success',
+    data: {
+      groups: [
+        {
+          rules: []
+        }
+      ]
+    }
+  })
+}
+
+async function misc (req, res) {
+  res.send({ status: 'success', data: {} })
+}
+
+module.exports = {
+  buildinfo,
+  rules,
+  misc
+}

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -17,7 +17,7 @@ async function handler (req, res) {
            }
         })
       break
-    case '/api/v1/rules'
+    case '/api/v1/rules':
       res.send("data": {
         "status": "success", 
           "groups": [

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -1,8 +1,9 @@
 /* Emulated PromQL Query Handler */
 
 async function handler (req, res) {
-  const path = new Url(req.url).pathname
+  const path = req.url
   req.log.debug('PROM Handler',path)
+  console.log('PROMOMOMOM path', path)
   switch (path) {
     case '/api/v1/status/buildinfo':
       res.send(

--- a/lib/handlers/prom_default.js
+++ b/lib/handlers/prom_default.js
@@ -3,7 +3,6 @@
 async function handler (req, res) {
   const path = req.url
   req.log.debug('PROM Handler',path)
-  console.log('PROMOMOMOM path', path)
   switch (path) {
     case '/api/v1/status/buildinfo':
       res.send(

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -4,6 +4,8 @@ const { p2l } = require('@qxip/promql2logql');
 const { asyncLogError } = require('../../common')
 const empty = '{"status" : "success", "data" : {"resultType" : "scalar", "result" : []}}'; // to be removed
 const test = () => `{"status" : "success", "data" : {"resultType" : "scalar", "result" : [${Math.floor(Date.now() / 1000)}, "2"]}}`; // to be removed
+const exec = (val) => `{"status" : "success", "data" : {"resultType" : "scalar", "result" : [${Math.floor(Date.now() / 1000)}, val]}}`; // to be removed
+
 
 async function handler (req, res) {
   req.log.debug('GET /loki/api/v1/query')
@@ -17,6 +19,9 @@ async function handler (req, res) {
   }
   if (req.query.query === '1+1') {
     return res.status(200).send(test())
+  }
+  else if (req.query.query === '1') {
+    return res.status(200).send(exec(1))
   }
   /* remove newlines */
   req.query.query = req.query.query.replace(/\n/g, ' ')

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -8,6 +8,9 @@ const test = () => `{"status" : "success", "data" : {"resultType" : "scalar", "r
 async function handler (req, res) {
   req.log.debug('GET /loki/api/v1/query')
   const resp = { streams: [] }
+  if (req.method === 'POST') {
+    req.query = req.body
+  }
   if (!req.query.query) {
     res.send(resp)
     return

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -9,7 +9,13 @@ const exec = (val) => `{"status" : "success", "data" : {"resultType" : "scalar",
 
 async function handler (req, res) {
   req.log.debug('GET /loki/api/v1/query')
-  const resp = { streams: [] }
+  const resp = {
+    status: "success",
+    data: {
+      resultType: "vector",
+      result: []
+    }
+  }
   if (req.method === 'POST') {
     req.query = req.body
   }

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -20,8 +20,8 @@ async function handler (req, res) {
   if (req.query.query === '1+1') {
     return res.status(200).send(test())
   }
-  else if (req.query.query === '1') {
-    return res.status(200).send(exec(1))
+  else if (!isNaN(parseInt(req.query.query))) {
+    return res.status(200).send(exec(parseInt(req.query.query)))
   }
   /* remove newlines */
   req.query.query = req.query.query.replace(/\n/g, ' ')

--- a/lib/handlers/prom_query_range.js
+++ b/lib/handlers/prom_query_range.js
@@ -15,6 +15,9 @@ const { asyncLogError } = require('../../common')
 async function handler (req, res) {
   req.log.debug('GET /api/v1/query_range')
   const resp = { streams: [] }
+  if (req.method === 'POST') {
+    req.query = req.body
+  }
   if (!req.query.query) {
     res.send(resp)
     return

--- a/lib/handlers/prom_query_range.js
+++ b/lib/handlers/prom_query_range.js
@@ -14,7 +14,13 @@ const { asyncLogError } = require('../../common')
 
 async function handler (req, res) {
   req.log.debug('GET /api/v1/query_range')
-  const resp = { streams: [] }
+  const resp = {
+    status: "success",
+    data: {
+      resultType: "vector",
+      result: []
+    }
+  }
   if (req.method === 'POST') {
     req.query = req.body
   }

--- a/lib/handlers/prom_series.js
+++ b/lib/handlers/prom_series.js
@@ -2,7 +2,7 @@ const { scanSeries } = require('../db/clickhouse')
 const { prom2labels, prom2log } = require('@qxip/promql2logql')
 
 // Series Handler
-async function handler (req, res)
+async function handler (req, res) {
   const query = req.query.match || req.query['match[]']
   // bypass queries unhandled by transpiler
   if (query.includes('node_info')){

--- a/lib/handlers/prom_series.js
+++ b/lib/handlers/prom_series.js
@@ -2,10 +2,15 @@ const { scanSeries } = require('../db/clickhouse')
 const { prom2labels, prom2log } = require('@qxip/promql2logql')
 
 // Series Handler
-async function handler (req, res) {
+async function handler (req, res)
+  const query = req.query.match || req.query['match[]']
+  // bypass queries unhandled by transpiler
+  if (query.includes('node_info')){
+    res.send({ status: 'success', data: [] })
+    return
+  }
   // convert the input query into a label selector
-  const labels = prom2labels(req.query.match || req.query['match[]'])
-  // console.log(req.query.match, labels)
+  const labels = prom2labels(query)
   let match = getArray(labels)
   if (!match.length) {
     throw new Error('Match param is required')

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@fastify/cors": "^8.1.0",
     "@fastify/static": "^6.5.0",
     "@fastify/websocket": "^7.1.1",
-    "@fastify/formbody": "^7.0.1",
+    "@fastify/formbody": "^7.4.0",
     "@qxip/influx-line-protocol-parser": "^0.2.1",
     "@qxip/plugnplay": "^3.3.1",
     "axios": "^0.21.4",

--- a/parsers.js
+++ b/parsers.js
@@ -13,9 +13,21 @@ const path = require('path')
 const WriteRequest = protobufjs.loadSync(path.join(__dirname, 'lib', 'prompb.proto')).lookupType('WriteRequest')
 const PushRequest = protobufjs.loadSync(path.join(__dirname, 'lib', 'loki.proto')).lookupType('PushRequest')
 const OTLPTraceData = protobufjs.loadSync(path.join(__dirname, 'lib', 'otlp.proto')).lookupType('TracesData')
+const { parse: queryParser } = require('fast-querystring')
+
 /**
  *
  * @param req {FastifyRequest}
+ * @returns {any}
+ */
+const wwwFormParser = async (req) => {
+  return queryParser(await getContentBody(req))
+}
+
+/**
+ *
+ * @param req {FastifyRequest}
+ *
  */
 const lokiPushJSONParser = async (req) => {
   try {
@@ -327,5 +339,6 @@ module.exports = {
   prometheusPushProtoParser,
   tempoNDJsonParser,
   otlpPushProtoParser,
+  wwwFormParser,
   parsers
 }

--- a/qryn.js
+++ b/qryn.js
@@ -91,7 +91,9 @@ let fastify = require('fastify')({
 
 fastify.register(require('fastify-url-data'))
 fastify.register(require('@fastify/websocket'))
-fastify.register(require('@fastify/formbody'))
+
+/* Formbody parser for Prometheus Checks */
+fastify.register(require('@fastify/formbody'), { prefix: '/api/v1/' })
 
 /* Fastify local metrics exporter */
 if (process.env.FASTIFY_METRICS) {

--- a/qryn.js
+++ b/qryn.js
@@ -307,7 +307,7 @@ fastify.post('/prom/remote/write', promWriteHandler, {
 
 /* PROMQETHEUS API EMULATION */
 const handlerPromQueryRange = require('./lib/handlers/prom_query_range.js').bind(this)
-fastify.get('/api/v1/query_range', handlerPromQueryRange)
+fastify.all('/api/v1/query_range', handlerPromQueryRange)
 const handlerPromQuery = require('./lib/handlers/prom_query.js').bind(this)
 fastify.all('/api/v1/query', handlerPromQuery)
 const handlerPromLabel = require('./lib/handlers/promlabel.js').bind(this)

--- a/qryn.js
+++ b/qryn.js
@@ -93,7 +93,7 @@ fastify.register(require('fastify-url-data'))
 fastify.register(require('@fastify/websocket'))
 
 /* Formbody parser for Prometheus Checks */
-fastify.register(require('@fastify/formbody'), { prefix: '/api/v1/' })
+fastify.register(require('@fastify/formbody'), { options: { prefix: '/api/v1/'} })
 
 /* Fastify local metrics exporter */
 if (process.env.FASTIFY_METRICS) {

--- a/qryn.js
+++ b/qryn.js
@@ -215,6 +215,11 @@ fastify.post('/tempo/api/push', handlerTempoPush, {
   'application/x-ndjson': tempoPushNDJSONParser,
   '*': tempoPushParser
 })
+fastify.post('/tempo/spans', handlerTempoPush, {
+  'application/json': tempoPushParser,
+  'application/x-ndjson': tempoPushNDJSONParser,
+  '*': tempoPushParser
+})
 fastify.post('/api/v2/spans', handlerTempoPush, {
   'application/json': tempoPushParser,
   'application/x-ndjson': tempoPushNDJSONParser,

--- a/qryn.js
+++ b/qryn.js
@@ -332,11 +332,11 @@ fastify.post('/api/v1/labels', handlerPromLabel, {
 fastify.post('/api/v1/label/:name/values', handlerPromLabelValues, {
   '*': rawStringParser
 }) // piggyback on qryn values
-const handlerPromDefault = require('./lib/handlers/prom_default.js').bind(this)
-fastify.get('/api/v1/metadata', handlerPromDefault) // default handler TBD
-fastify.get('/api/v1/rules', handlerPromDefault) // default handler TBD
-fastify.get('/api/v1/query_exemplars', handlerPromDefault) // default handler TBD
-fastify.get('/api/v1/status/buildinfo', handlerPromDefault) // default handler TBD
+const handlerPromDefault = require('./lib/handlers/prom_default.js')
+fastify.get('/api/v1/metadata', handlerPromDefault.misc.bind(this)) // default handler TBD
+fastify.get('/api/v1/rules', handlerPromDefault.rules.bind(this)) // default handler TBD
+fastify.get('/api/v1/query_exemplars', handlerPromDefault.misc.bind(this)) // default handler TBD
+fastify.get('/api/v1/status/buildinfo', handlerPromDefault.buildinfo.bind(this)) // default handler TBD
 
 /* NewRelic Log Handler */
 const handlerNewrelicLogPush = require('./lib/handlers/newrelic_log_push.js').bind(this)

--- a/qryn.js
+++ b/qryn.js
@@ -91,7 +91,7 @@ let fastify = require('fastify')({
 
 fastify.register(require('fastify-url-data'))
 fastify.register(require('@fastify/websocket'))
-// fastify.register(require('@fastify/formbody'))
+fastify.register(require('@fastify/formbody'))
 
 /* Fastify local metrics exporter */
 if (process.env.FASTIFY_METRICS) {


### PR DESCRIPTION
The PromQL scope is limited and certain commands should be excluded from the transpiler.
Example: `node_info` seems to be used as ping by a few prometheus drivers and fails validation.

Certain APIs were only implemented with Grafana in mind. Missing routes/methods should be backfilled.