### PR TITLE
fix: logfmt should produce 0 or more extra labels

### DIFF
--- a/parser/registry/parser_registry/logfmt.js
+++ b/parser/registry/parser_registry/logfmt.js
@@ -1,4 +1,5 @@
 const { map, addStream } = require('../common')
+const logfmt = require('logfmt')
 
 /**
  *
@@ -13,60 +14,8 @@ module.exports.viaStream = (token, query) => {
     */
 
   const extractLabels = (line) => {
-    let key = ''
-    let value = ''
-    let isKey = false
-    let inValue = false
-    let inQuote = false
-    let hadQuote = false
-    const object = {}
-
-    if (line[line.length - 1] === '\n') {
-      line = line.slice(0, line.length - 1)
-    }
-
-    for (let i = 0; i <= line.length; i++) {
-      if ((line[i] === ' ' && !inQuote) || i === line.length) {
-        if (isKey && key.length > 0) {
-          object[key] = true
-        } else if (inValue) {
-          if (value === 'true') value = true
-          else if (value === 'false') value = false
-          else if (value === '' && !hadQuote) value = null
-          object[key] = value
-          value = ''
-        }
-
-        if (i === line.length) break
-        else {
-          isKey = false
-          inValue = false
-          inQuote = false
-          hadQuote = false
-        }
-      }
-
-      if (line[i] === '=' && !inQuote) {
-        // split
-        isKey = false
-        inValue = true
-      } else if (line[i] === '\\') {
-        i++
-        value += line[i]
-      } else if (line[i] === '"') {
-        hadQuote = true
-        inQuote = !inQuote
-      } else if (line[i] !== ' ' && !inValue && !isKey) {
-        isKey = true
-        key = line[i]
-      } else if (isKey) {
-        key += line[i]
-      } else if (inValue) {
-        value += line[i]
-      }
-    }
-
-    return object
+    const labels = logfmt.parse(line)
+    return Object.fromEntries(Object.entries(labels).filter(([k, v]) => typeof v === 'string'))
   }
 
   /**


### PR DESCRIPTION
Example:
line: `INFO: <script>: Reply from Inbound - S=123 - Proxy Authentication Required M=INVITE IP=udp:127.0.0.1:1234 ID=abcd@127.0.0.1`
parse result: 
```
{
  S: '123',
  M: 'INVITE',
  IP: 'udp:127.0.0.1:1234',
  ID: 'abcd@127.0.0.1'
}
```

