### PR TITLE
fix: res.status is not a function

### DIFF
--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -22,9 +22,9 @@ async function handler (req, res) {
     return res.send(resp)
   }
   if (req.query.query === '1+1') {
-    return res.status(200).send(test())
+    return res.code(200).send(test())
   } else if (!isNaN(parseInt(req.query.query))) {
-    return res.status(200).send(exec(parseInt(req.query.query)))
+    return res.code(200).send(exec(parseInt(req.query.query)))
   }
   /* remove newlines */
   req.query.query = req.query.query.replace(/\n/g, ' ')


### PR DESCRIPTION
```
root-qryn-1 | 20 | }
root-qryn-1 | 21 | if (!req.query.query) {
root-qryn-1 | 22 | return res.send(resp)
root-qryn-1 | 23 | }
root-qryn-1 | 24 | if (req.query.query === '1+1') {
root-qryn-1 | 25 | return res.status(200).send(test())
root-qryn-1 | ^
root-qryn-1 | TypeError: res.status is not a function. (In 'res.status(200)', 'res.status' is undefined)
```