### PR TITLE
Small fixes

### DIFF
--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -198,17 +198,8 @@ const initialize = async function (dbName) {
 
 const checkCapabilities = async () => {
   logger.info('Checking clickhouse capabilities')
-  try {
-    await axios.post(getClickhouseUrl() + '/?allow_experimental_live_view=1',
-      `CREATE LIVE VIEW IF NOT EXISTS ${clickhouseOptions.queryOptions.database}.lvcheck AS SELECT 1`)
-    await axios.post(getClickhouseUrl() + '/?allow_experimental_live_view=1',
-      `DROP VIEW IF EXISTS ${clickhouseOptions.queryOptions.database}.lvcheck`)
-    capabilities.liveView = !isCustomSamplesOrderingRule()
-    logger.info('LIVE VIEW: supported')
-  } catch (e) {
-    logger.info('LIVE VIEW: unsupported')
-    capabilities.liveView = false
-  }
+  // qryn doesn't use LIVE VIEW after ClickHouse dropped WITH TIMEOUT clause support
+  capabilities.liveView = false
 }
 
 const reloadFingerprints = function () {

--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -200,7 +200,9 @@ const checkCapabilities = async () => {
   logger.info('Checking clickhouse capabilities')
   try {
     await axios.post(getClickhouseUrl() + '/?allow_experimental_live_view=1',
-      `CREATE LIVE VIEW ${clickhouseOptions.queryOptions.database}.lvcheck WITH TIMEOUT 1 AS SELECT 1`)
+      `CREATE LIVE VIEW IF NOT EXISTS ${clickhouseOptions.queryOptions.database}.lvcheck AS SELECT 1`)
+    await axios.post(getClickhouseUrl() + '/?allow_experimental_live_view=1',
+      `DROP VIEW IF EXISTS ${clickhouseOptions.queryOptions.database}.lvcheck`)
     capabilities.liveView = !isCustomSamplesOrderingRule()
     logger.info('LIVE VIEW: supported')
   } catch (e) {
@@ -331,7 +333,7 @@ const tempoSearchScan = async function (query, res) {
 }
 
 /**
- * 
+ *
  * @param traces {Object[]} openzipkin traces array see https://zipkin.io/zipkin-api/#/default/post_spans
  * @returns {Promise<unknown>}
  */
@@ -433,8 +435,8 @@ const queryTempoScan = async function (query) {
 }
 
 const queryTempoScanV2 = async function (query) {
-  const select = `SELECT hex(trace_id) as traceID, service_name as rootServiceName, 
-    name as rootTraceName, timestamp_ns as startTimeUnixNano, 
+  const select = `SELECT hex(trace_id) as traceID, service_name as rootServiceName,
+    name as rootTraceName, timestamp_ns as startTimeUnixNano,
     intDiv(duration_ns, 1000000) as durationMs`
   const from = `FROM ${DATABASE_NAME()}.tempo_traces${dist}`
   const where = [
@@ -476,7 +478,7 @@ const queryTempoScanV2 = async function (query) {
 
 async function queryTempoTags () {
   const q = `SELECT distinct key
-    FROM ${DATABASE_NAME()}.tempo_traces_kv${dist} 
+    FROM ${DATABASE_NAME()}.tempo_traces_kv${dist}
     WHERE oid='0' AND date >= toDate(NOW()) - interval '1 day'
     FORMAT JSON`
   const resp = await axios.post(getClickhouseUrl() + '/',q)
@@ -490,7 +492,7 @@ async function queryTempoTags () {
  */
 async function queryTempoValues (tag) {
   const q = `SELECT distinct val
-    FROM ${DATABASE_NAME()}.tempo_traces_kv${dist} 
+    FROM ${DATABASE_NAME()}.tempo_traces_kv${dist}
     WHERE oid='0' AND date >= toDate(NOW()) - interval '1 day' AND key = ${csql.quoteVal(tag)}
     FORMAT JSON`
   const resp = await axios.post(getClickhouseUrl() + '/', q)
@@ -1380,7 +1382,7 @@ const rawRequest = async (query, data, database, config) => {
 const getSettings = async (names, database) => {
   const fps = names.map(n => UTILS.fingerPrint(JSON.stringify({ type: n.type, name: n.name }), false,
     'short-hash'))
-  const settings = await rawRequest(`SELECT argMax(name, inserted_at) as _name, 
+  const settings = await rawRequest(`SELECT argMax(name, inserted_at) as _name,
         argMax(value, inserted_at) as _value
         FROM settings${dist} WHERE fingerprint IN (${fps.join(',')}) GROUP BY fingerprint HAVING _name != '' FORMAT JSON`,
   null, database)

--- a/lib/handlers/prom_query.js
+++ b/lib/handlers/prom_query.js
@@ -22,13 +22,13 @@ async function handler (req, res) {
     return res.send(resp)
   }
   if (req.query.query === '1+1') {
-    return res.code(200).send(test())
-  } else if (!isNaN(parseInt(req.query.query))) {
-    return res.code(200).send(exec(parseInt(req.query.query)))
+    return res.status(200).send(test())
+  } else if (Number(req.query.query)) {
+    return res.status(200).send(exec(Number(req.query.query)))
   }
   /* remove newlines */
   req.query.query = req.query.query.replace(/\n/g, ' ')
-  req.query.time = req.query.time ? parseInt(req.query.time) * 1000 : Date.now()
+  req.query.time = req.query.time ? Number(req.query.time) * 1000 : Date.now()
   /* transpile to logql */
   try {
     const response = await instantQuery(req.query.query, req.query.time)

--- a/promql/index.js
+++ b/promql/index.js
@@ -89,7 +89,7 @@ const getMatchersIdxCond = (matchers) => {
         _matcher.push(Sql.Eq(new Sql.Raw(`match(val, ${Sql.quoteVal(matcher[2])})`), 1))
         break
       case '!~':
-        _matcher.push(Sql.Ne(Sql.Raw(`match(val, ${Sql.quoteVal(matcher[2])})`), 1))
+        _matcher.push(Sql.Ne(new Sql.Raw(`match(val, ${Sql.quoteVal(matcher[2])})`), 1))
     }
     matchesCond.push(Sql.And(..._matcher))
   }


### PR DESCRIPTION
- [ClickHouse 22.10 removed support for the WITH TIMEOUT section for LIVE VIEW ](https://clickhouse.com/docs/en/whats-new/changelog/2022#backward-incompatible-change-1). Try to create temporary live view then drop it.
- Missing `new` in matcher transpiler causes request to crash.
- `parseInt` doesn't fail if there is letters, allowing garbage input.
