### PR TITLE
Support legacy Elastic _bulk API clients which use `Content-Type: application/json`

### DIFF
--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -472,7 +472,6 @@ const queryTempoScanV2 = async function (query) {
   }
   const limit = query.limit ? `LIMIT ${parseInt(query.limit)}` : ''
   const sql = `${select} ${from} WHERE ${where.join(' AND ')} ORDER BY timestamp_ns DESC ${limit} FORMAT JSON`
-  console.log(sql)
   const resp = await rawRequest(sql, null, process.env.CLICKHOUSE_DB || 'cloki')
   return resp.data.data ? resp.data.data : JSON.parse(resp.data).data
 }

--- a/lib/handlers/elastic_bulk.js
+++ b/lib/handlers/elastic_bulk.js
@@ -26,17 +26,7 @@ async function handler (req, res) {
 
   const docTarget = req.params.target || false
 
-  let streams
-  if (
-    req.headers['content-type'] &&
-                req.headers['content-type'].indexOf('application/x-ndjson') > -1
-  ) {
-    // ndjson body
-    streams = req.body.split(/\n/)
-  } else {
-    // assume ndjson raw body
-    streams = req.body.split(/\n/)
-  }
+  const streams = req.body.split(/\n/)
   let lastTags = false
   const promises = []
   if (streams) {

--- a/lib/handlers/query.js
+++ b/lib/handlers/query.js
@@ -8,7 +8,6 @@ async function handler (req, res) {
   if (!req.query.query) {
     return res.send(resp)
   }
-  console.log(req.query.query)
   const m = req.query.query.match(/^vector *\( *([0-9]+) *\) *\+ *vector *\( *([0-9]+) *\)/)
   if (m) {
     return res.code(200).send(JSON.stringify({

--- a/parser/transpiler.js
+++ b/parser/transpiler.js
@@ -239,7 +239,6 @@ module.exports.transpile = (request) => {
   setQueryParam(query, sharedParamNames.from, start + '000000')
   setQueryParam(query, sharedParamNames.to, end + '000000')
   setQueryParam(query, 'isMatrix', query.ctx.matrix)
-  console.log(query.toString())
   return {
     query: request.rawQuery ? query : query.toString(),
     matrix: !!query.ctx.matrix,

--- a/pyroscope/shared.js
+++ b/pyroscope/shared.js
@@ -66,7 +66,7 @@ const wrapResponse = (hndl) => {
       const strRes = JSON.stringify(normalizeProtoResponse(_res.toObject()))
       return res.code(200).send(strRes)
     }
-    return res.code(200).send(Buffer.from(_res.serializeBinary()))
+    return res.code(200).type('application/proto').send(Buffer.from(_res.serializeBinary()))
   }
 }
 

--- a/qryn_node.js
+++ b/qryn_node.js
@@ -243,11 +243,9 @@ let fastify = require('fastify')({
   })
   const handlerElasticBulk = require('./lib/handlers/elastic_bulk.js').bind(this)
   writerMode && fastify.post('/_bulk', handlerElasticBulk, {
-    'application/json': jsonParser,
     '*': rawStringParser
   })
   writerMode && fastify.post('/:target/_bulk', handlerElasticBulk, {
-    'application/json': jsonParser,
     '*': rawStringParser
   })
 


### PR DESCRIPTION
Changes the Elastic bulk API parser to support requests with `Content-Type: application/json`, by sending all requests through the same code path. (the existing parser behaviour expected a single JSON object for `application/json` -- though that code path would error anyway -- which is still supported as the case where there is 1 object / no newlines).

Resolves https://github.com/metrico/qryn/issues/602