### PR TITLE
Remove some noisy `console.log` statements

### DIFF
--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -472,7 +472,6 @@ const queryTempoScanV2 = async function (query) {
   }
   const limit = query.limit ? `LIMIT ${parseInt(query.limit)}` : ''
   const sql = `${select} ${from} WHERE ${where.join(' AND ')} ORDER BY timestamp_ns DESC ${limit} FORMAT JSON`
-  console.log(sql)
   const resp = await rawRequest(sql, null, process.env.CLICKHOUSE_DB || 'cloki')
   return resp.data.data ? resp.data.data : JSON.parse(resp.data).data
 }

--- a/lib/handlers/query.js
+++ b/lib/handlers/query.js
@@ -8,7 +8,6 @@ async function handler (req, res) {
   if (!req.query.query) {
     return res.send(resp)
   }
-  console.log(req.query.query)
   const m = req.query.query.match(/^vector *\( *([0-9]+) *\) *\+ *vector *\( *([0-9]+) *\)/)
   if (m) {
     return res.code(200).send(JSON.stringify({

--- a/parser/transpiler.js
+++ b/parser/transpiler.js
@@ -239,7 +239,6 @@ module.exports.transpile = (request) => {
   setQueryParam(query, sharedParamNames.from, start + '000000')
   setQueryParam(query, sharedParamNames.to, end + '000000')
   setQueryParam(query, 'isMatrix', query.ctx.matrix)
-  console.log(query.toString())
   return {
     query: request.rawQuery ? query : query.toString(),
     matrix: !!query.ctx.matrix,


### PR DESCRIPTION
Removes quite a few lines that end up in log files (which also then end up in ClickHouse if logs are forwarded for `qryn`).