### PR TITLE
Set "Content-Type: application/proto" for pyroscope `QuerierService` responses

### DIFF
--- a/pyroscope/shared.js
+++ b/pyroscope/shared.js
@@ -66,7 +66,7 @@ const wrapResponse = (hndl) => {
       const strRes = JSON.stringify(normalizeProtoResponse(_res.toObject()))
       return res.code(200).send(strRes)
     }
-    return res.code(200).send(Buffer.from(_res.serializeBinary()))
+    return res.code(200).type('application/proto').send(Buffer.from(_res.serializeBinary()))
   }
 }
 


### PR DESCRIPTION
Latest Grafana (11.5.2 at time of writing this) appears to require "`Content-Type: application/proto`" for responses from pyroscope `QuerierService`. (previously, "`Content-Type: application/octet-stream`" was used: the fastify default).